### PR TITLE
[PIPE-3247] Return all function name types

### DIFF
--- a/include/llvm/DebugInfo/DIContext.h
+++ b/include/llvm/DebugInfo/DIContext.h
@@ -31,7 +31,9 @@ class raw_ostream;
 /// DILineInfo - a format-neutral container for source line information.
 struct DILineInfo {
   std::string FileName;
-  std::string FunctionName;
+  std::string ShortFunctionName;
+  std::string LinkageFunctionName;
+  std::string SymbolTableFunctionName;
   uint32_t Line = 0;
   uint32_t Column = 0;
   uint32_t StartLine = 0;
@@ -39,20 +41,25 @@ struct DILineInfo {
   // DWARF-specific.
   uint32_t Discriminator = 0;
 
-  DILineInfo() : FileName("<invalid>"), FunctionName("<invalid>") {}
+  DILineInfo() : FileName("<invalid>"), ShortFunctionName("<invalid>"),
+    LinkageFunctionName("<invalid>"), SymbolTableFunctionName("<invalid>") {}
 
   bool operator==(const DILineInfo &RHS) const {
     return Line == RHS.Line && Column == RHS.Column &&
-           FileName == RHS.FileName && FunctionName == RHS.FunctionName &&
+           FileName == RHS.FileName && ShortFunctionName == RHS.ShortFunctionName &&
+           LinkageFunctionName == RHS.LinkageFunctionName &&
+           SymbolTableFunctionName == RHS.SymbolTableFunctionName &&
            StartLine == RHS.StartLine && Discriminator == RHS.Discriminator;
   }
   bool operator!=(const DILineInfo &RHS) const {
     return !(*this == RHS);
   }
   bool operator<(const DILineInfo &RHS) const {
-    return std::tie(FileName, FunctionName, Line, Column, StartLine,
+    return std::tie(FileName, ShortFunctionName, LinkageFunctionName,
+                    SymbolTableFunctionName, Line, Column, StartLine,
                     Discriminator) <
-           std::tie(RHS.FileName, RHS.FunctionName, RHS.Line, RHS.Column,
+           std::tie(RHS.FileName, RHS.ShortFunctionName, RHS.LinkageFunctionName,
+                    RHS.SymbolTableFunctionName, RHS.Line, RHS.Column,
                     RHS.StartLine, RHS.Discriminator);
   }
 };

--- a/include/llvm/DebugInfo/PDB/PDBContext.h
+++ b/include/llvm/DebugInfo/PDB/PDBContext.h
@@ -57,7 +57,7 @@ namespace pdb {
         DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
 
   private:
-    std::string getFunctionName(uint64_t Address, DINameKind NameKind) const;
+    void getFunctionName(uint64_t Address, DINameKind NameKind, std::string &ShortFunctionName, std::string &LinkageFunctionName) const;
     std::unique_ptr<IPDBSession> Session;
   };
 

--- a/include/llvm/DebugInfo/Symbolize/DIPrinter.h
+++ b/include/llvm/DebugInfo/Symbolize/DIPrinter.h
@@ -33,6 +33,7 @@ class DIPrinter {
 
   void print(const DILineInfo &Info, bool Inlined);
   void printContext(const std::string &FileName, int64_t Line);
+  std::string escapeJson(const std::string &s);
 
 public:
   DIPrinter(raw_ostream &OS, bool PrintFunctionNames = true,

--- a/lib/DebugInfo/Symbolize/DIPrinter.cpp
+++ b/lib/DebugInfo/Symbolize/DIPrinter.cpp
@@ -74,7 +74,7 @@ void DIPrinter::print(const DILineInfo &Info, bool Inlined) {
     OS << "\"linkageFunctionName\":" << (Info.LinkageFunctionName == kDILineInfoBadString ? "null" : "\"" + escapeJson(Info.LinkageFunctionName) + "\"") << ",";
     OS << "\"symbolTableFunctionName\":" << (Info.SymbolTableFunctionName == kDILineInfoBadString ? "null" : "\"" + escapeJson(Info.SymbolTableFunctionName) + "\"") << ",";
   }
-  OS << "\"fileName\":\"" << escapeJson(Info.FileName) << "\",";
+  OS << "\"fileName\":" << (Info.FileName == kDILineInfoBadString ? "null" : "\"" + escapeJson(Info.FileName) + "\"") << ",";
   OS << "\"startLine\":" << (Info.StartLine ? std::to_string(Info.StartLine) : "null") << ",";
   OS << "\"line\":" << std::to_string(Info.Line) << ",";
   OS << "\"column\":" << std::to_string(Info.Column) << ",";

--- a/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -71,8 +71,11 @@ Expected<DILineInfo> LLVMSymbolizer::symbolizeCode(const std::string &ModuleName
 
   DILineInfo LineInfo = Info->symbolizeCode(ModuleOffset, Opts.PrintFunctions,
                                             Opts.UseSymbolTable);
-  if (Opts.Demangle)
-    LineInfo.FunctionName = DemangleName(LineInfo.FunctionName, Info);
+  if (Opts.Demangle) {
+    LineInfo.ShortFunctionName = DemangleName(LineInfo.ShortFunctionName, Info);
+    LineInfo.LinkageFunctionName = DemangleName(LineInfo.LinkageFunctionName, Info);
+    LineInfo.SymbolTableFunctionName = DemangleName(LineInfo.SymbolTableFunctionName, Info);
+  }
   return LineInfo;
 }
 
@@ -100,7 +103,9 @@ LLVMSymbolizer::symbolizeInlinedCode(const std::string &ModuleName,
   if (Opts.Demangle) {
     for (int i = 0, n = InlinedContext.getNumberOfFrames(); i < n; i++) {
       auto *Frame = InlinedContext.getMutableFrame(i);
-      Frame->FunctionName = DemangleName(Frame->FunctionName, Info);
+      Frame->ShortFunctionName = DemangleName(Frame->ShortFunctionName, Info);
+      Frame->LinkageFunctionName = DemangleName(Frame->ShortFunctionName, Info);
+      Frame->SymbolTableFunctionName = DemangleName(Frame->SymbolTableFunctionName, Info);
     }
   }
   return InlinedContext;

--- a/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -104,7 +104,7 @@ LLVMSymbolizer::symbolizeInlinedCode(const std::string &ModuleName,
     for (int i = 0, n = InlinedContext.getNumberOfFrames(); i < n; i++) {
       auto *Frame = InlinedContext.getMutableFrame(i);
       Frame->ShortFunctionName = DemangleName(Frame->ShortFunctionName, Info);
-      Frame->LinkageFunctionName = DemangleName(Frame->ShortFunctionName, Info);
+      Frame->LinkageFunctionName = DemangleName(Frame->LinkageFunctionName, Info);
       Frame->SymbolTableFunctionName = DemangleName(Frame->SymbolTableFunctionName, Info);
     }
   }

--- a/tools/llvm-symbolizer/llvm-symbolizer.cpp
+++ b/tools/llvm-symbolizer/llvm-symbolizer.cpp
@@ -181,11 +181,11 @@ int main(int argc, char **argv) {
       continue;
     }
 
+    outs() << "{";
     if (ClPrintAddress) {
-      outs() << "0x";
+      outs() << "\"address\":\"0x";
       outs().write_hex(ModuleOffset);
-      StringRef Delimiter = (ClPrettyPrint == true) ? ": " : "\n";
-      outs() << Delimiter;
+      outs() << "\",";
     }
     if (IsData) {
       auto ResOrErr = Symbolizer.symbolizeData(ModuleName, ModuleOffset);
@@ -198,7 +198,7 @@ int main(int argc, char **argv) {
       auto ResOrErr = Symbolizer.symbolizeCode(ModuleName, ModuleOffset);
       Printer << (error(ResOrErr) ? DILineInfo() : ResOrErr.get());
     }
-    outs() << "\n";
+    outs() << "}\n";
     outs().flush();
   }
 


### PR DESCRIPTION
If any function name type is requested we now return all three types:
- Linkage from debug info
- Linkage from symbol table
- Short from debug info

Output is now in a custom format with each line a JSON object to
facilitate easier parsing in our wrapper library.