### PR TITLE
PIPE-4273: Better address handling

### DIFF
--- a/include/llvm/DebugInfo/Symbolize/BugsnagSymbolize.h
+++ b/include/llvm/DebugInfo/Symbolize/BugsnagSymbolize.h
@@ -22,7 +22,7 @@ typedef struct SymbolizeResults {
   SymbolizeResult* results;
 } SymbolizeResults;
 
-SymbolizeResults BugsnagSymbolize(const char* filePath, bool includeInline, int64_t addresses[], int addressCount);
+SymbolizeResults BugsnagSymbolize(const char* filePath, bool includeInline, char* addresses[], int addressCount);
 void DestroySymbolizeResults(SymbolizeResults* symbolizeResults);
 
 #ifdef __cplusplus

--- a/include/llvm/DebugInfo/Symbolize/BugsnagSymbolize.h
+++ b/include/llvm/DebugInfo/Symbolize/BugsnagSymbolize.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 typedef struct SymbolizeResult {
-  int64_t address;
+  char* address;
   bool inlined;
   char* fileName;
   char* shortFunctionName;

--- a/include/llvm/DebugInfo/Symbolize/BugsnagSymbolize.h
+++ b/include/llvm/DebugInfo/Symbolize/BugsnagSymbolize.h
@@ -15,6 +15,7 @@ typedef struct SymbolizeResult {
   int line;
   int column;
   int startLine;
+  bool badAddress;
 } SymbolizeResult;
 
 typedef struct SymbolizeResults {

--- a/lib/DebugInfo/Symbolize/BugsnagSymbolize.cpp
+++ b/lib/DebugInfo/Symbolize/BugsnagSymbolize.cpp
@@ -72,23 +72,22 @@ SymbolizeResults BugsnagSymbolize(const char* filePath, bool includeInline, char
   std::vector<SymbolizeResult> results;
 
   for (int i = 0; i < addressCount; i++) {
-    std::string stringAddress = addresses[i];
+    std::string hexAddress = addresses[i];
     char* addressErr;
-    int64_t numericAddress = (int64_t)std::strtoul(stringAddress.c_str(), &addressErr, 16);
-    auto ResOrErr = Symbolizer.symbolizeCode(moduleName, numericAddress);
+    int64_t numericAddress = (int64_t)std::strtoul(hexAddress.c_str(), &addressErr, 16);
 
     if (includeInline) {
       auto ResOrErr = Symbolizer.symbolizeInlinedCode(moduleName, numericAddress);
       if (ResOrErr) {
         for (int j = 0; j < ResOrErr.get().getNumberOfFrames(); j++) {
-          SymbolizeResult result = getSymbolizeResult(ResOrErr.get().getFrame(j), stringAddress, (j == 0) ? false: true, (*addressErr == 0) ? false: true);
+          SymbolizeResult result = getSymbolizeResult(ResOrErr.get().getFrame(j), hexAddress, (j == 0) ? false: true, *addressErr != 0);
           results.push_back(result);
         }
       }
     } else {
       auto ResOrErr = Symbolizer.symbolizeCode(moduleName, numericAddress);
       if (ResOrErr) {
-        SymbolizeResult result = getSymbolizeResult(ResOrErr.get(), stringAddress, false, (*addressErr == 0) ? false: true);
+        SymbolizeResult result = getSymbolizeResult(ResOrErr.get(), hexAddress, false, *addressErr != 0);
         results.push_back(result);
       }
     }

--- a/lib/DebugInfo/Symbolize/BugsnagSymbolize.cpp
+++ b/lib/DebugInfo/Symbolize/BugsnagSymbolize.cpp
@@ -14,6 +14,7 @@ static void destroySymbolizeResult(SymbolizeResult* symbolizeResult) {
   if (!symbolizeResult) {
     return;
   }
+  freeAndInvalidate((void**)&symbolizeResult->address);
   freeAndInvalidate((void**)&symbolizeResult->fileName);
   freeAndInvalidate((void**)&symbolizeResult->shortFunctionName);
   freeAndInvalidate((void**)&symbolizeResult->linkageFunctionName);


### PR DESCRIPTION
Call bugsnag symbolize with array of char pointers instead of integers is tidier than maintaining a conversion map.
Add a flag to the result if the conversion between hex string and integer failed. 