### PR TITLE
PIPE-8572: fix inlining output

### DIFF
--- a/lib/DebugInfo/Symbolize/DIPrinter.cpp
+++ b/lib/DebugInfo/Symbolize/DIPrinter.cpp
@@ -112,7 +112,9 @@ DIPrinter &DIPrinter::operator<<(const DILineInfo &Info) {
 DIPrinter &DIPrinter::operator<<(const DIInliningInfo &Info) {
   uint32_t FramesNum = Info.getNumberOfFrames();
   if (FramesNum == 0) {
+    OS << "{";
     print(DILineInfo(), false);
+    OS << "}";
     return *this;
   }
   for (uint32_t i = 0; i < FramesNum; i++) {

--- a/lib/DebugInfo/Symbolize/DIPrinter.cpp
+++ b/lib/DebugInfo/Symbolize/DIPrinter.cpp
@@ -117,15 +117,18 @@ DIPrinter &DIPrinter::operator<<(const DIInliningInfo &Info) {
     OS << "}";
     return *this;
   }
+  
+  bool inlined = false;
   for (uint32_t i = 0; i < FramesNum; i++) {
-    if (i == 0) {
-      OS << "{";
-    } else {
-      OS << ",{";
+    if (inlined) {
+      OS << ",";
     }
     
-    print(Info.getFrame(i), i > 0);
+    OS << "{";
+    print(Info.getFrame(i), inlined);
     OS << "}";
+
+    inlined = true;
   }
 
   return *this;

--- a/lib/DebugInfo/Symbolize/DIPrinter.cpp
+++ b/lib/DebugInfo/Symbolize/DIPrinter.cpp
@@ -115,8 +115,17 @@ DIPrinter &DIPrinter::operator<<(const DIInliningInfo &Info) {
     print(DILineInfo(), false);
     return *this;
   }
-  for (uint32_t i = 0; i < FramesNum; i++)
+  for (uint32_t i = 0; i < FramesNum; i++) {
+    if (i == 0) {
+      OS << "{";
+    } else {
+      OS << ",{";
+    }
+    
     print(Info.getFrame(i), i > 0);
+    OS << "}";
+  }
+
   return *this;
 }
 

--- a/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
+++ b/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
@@ -255,9 +255,32 @@ DIInliningInfo SymbolizableObjectFile::symbolizeInlinedCode(
     uint64_t ModuleOffset, FunctionNameKind FNKind, bool UseSymbolTable) const {
   DIInliningInfo InlinedContext;
 
-  if (DebugInfoContext)
+  if (DebugInfoContext){
     InlinedContext = DebugInfoContext->getInliningInfoForAddress(
         ModuleOffset, getDILineInfoSpecifier(FNKind));
+
+    // HACK: This strips projectRoot in the bugsnag-expected manner (on all frames).
+    // HACK: Upstream doesn't have the getCompilationDirectory() function.
+    if (InlinedContext.getNumberOfFrames() != 0) {
+      std::string Prefix = DebugInfoContext->getCompilationDirectory();
+      if (Prefix.back() != '/') {
+        Prefix.push_back('/');
+      }
+
+      for (int i=0; i<InlinedContext.getNumberOfFrames()-1; i++) {
+        DILineInfo* FrameLineInfo = InlinedContext.getMutableFrame(i);
+        if(FrameLineInfo) {
+          std::string FileName = FrameLineInfo->FileName;
+        
+          if (FileName.length() > Prefix.length() &&
+            FileName.substr(0, Prefix.length()) == Prefix) {
+            FrameLineInfo->FileName = FileName.substr(Prefix.length());
+          }
+        }
+      }
+    }
+  }
+  
   // Make sure there is at least one frame in context.
   if (InlinedContext.getNumberOfFrames() == 0)
     InlinedContext.addFrame(DILineInfo());

--- a/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
+++ b/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
@@ -263,7 +263,7 @@ DIInliningInfo SymbolizableObjectFile::symbolizeInlinedCode(
     // HACK: Upstream doesn't have the getCompilationDirectory() function.
     if (InlinedContext.getNumberOfFrames() != 0) {
       std::string Prefix = DebugInfoContext->getCompilationDirectory();
-      if (Prefix.back() != '/') {
+      if (!Prefix.empty() && Prefix.back() != '/') {
         Prefix.push_back('/');
       }
 

--- a/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
+++ b/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
@@ -267,7 +267,7 @@ DIInliningInfo SymbolizableObjectFile::symbolizeInlinedCode(
         Prefix.push_back('/');
       }
 
-      for (int i=0; i<InlinedContext.getNumberOfFrames()-1; i++) {
+      for (int i=0; i<InlinedContext.getNumberOfFrames(); i++) {
         DILineInfo* FrameLineInfo = InlinedContext.getMutableFrame(i);
         if(FrameLineInfo) {
           std::string FileName = FrameLineInfo->FileName;

--- a/tools/llvm-symbolizer/llvm-symbolizer.cpp
+++ b/tools/llvm-symbolizer/llvm-symbolizer.cpp
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
       auto ResOrErr = Symbolizer.symbolizeData(ModuleName, ModuleOffset);
       Printer << (error(ResOrErr) ? DIGlobal() : ResOrErr.get());
     } else if (ClPrintInlining) {
-      outs() << "\"inlinedFrames\":[";
+      outs() << "\"frames\":[";
       auto ResOrErr = Symbolizer.symbolizeInlinedCode(ModuleName, ModuleOffset);
       Printer << (error(ResOrErr) ? DIInliningInfo()
                                              : ResOrErr.get());

--- a/tools/llvm-symbolizer/llvm-symbolizer.cpp
+++ b/tools/llvm-symbolizer/llvm-symbolizer.cpp
@@ -191,9 +191,11 @@ int main(int argc, char **argv) {
       auto ResOrErr = Symbolizer.symbolizeData(ModuleName, ModuleOffset);
       Printer << (error(ResOrErr) ? DIGlobal() : ResOrErr.get());
     } else if (ClPrintInlining) {
+      outs() << "\"inlinedFrames\":[";
       auto ResOrErr = Symbolizer.symbolizeInlinedCode(ModuleName, ModuleOffset);
       Printer << (error(ResOrErr) ? DIInliningInfo()
                                              : ResOrErr.get());
+      outs() << "]";
     } else {
       auto ResOrErr = Symbolizer.symbolizeCode(ModuleName, ModuleOffset);
       Printer << (error(ResOrErr) ? DILineInfo() : ResOrErr.get());


### PR DESCRIPTION
We are now looking at returning inlined frames (PIPE-8546) for both c and cocoa frames, though this change only concerns cocoa/dsym symbolication.

When I initially tried requesting inlined frames the output line was not valid JSON and could not determine which frame is which in:
```
{"address":"0x100002206","inlined":false,"shortFunctionName":"handledError","linkageFunctionName":"$S15bugsnag_example14ViewControllerC12handledErroryyF","symbolTableFunctionName":null,"fileName":"/Users/mikebull/workspace/notifiers/bugsnag-cocoa/examples/swift-ios/<compiler-generated>","startLine":null,"line":0,"column":0,"discriminator":null"inlined":true,"shortFunctionName":"doCustomClassNotify","linkageFunctionName":"$S15bugsnag_example14ViewControllerC19doCustomClassNotifyyyyXlF","symbolTableFunctionName":null,"fileName":"/Users/mikebull/workspace/notifiers/bugsnag-cocoa/examples/swift-ios/bugsnag-example/Controllers/ViewController.swift","startLine":62,"line":63,"column":0,"discriminator":null"inlined":true,"shortFunctionName":"doCustomClassNotify","linkageFunctionName":"$S15bugsnag_example14ViewControllerC19doCustomClassNotifyyyyXlFTo","symbolTableFunctionName":"$S15bugsnag_example14ViewControllerC19doCustomClassNotifyyyyXlFTo","fileName":"/Users/mikebull/workspace/notifiers/bugsnag-cocoa/examples/swift-ios/<compiler-generated>","startLine":null,"line":62,"column":0,"discriminator":null}
```
I've added some JSON structure to the output so we now receive a list of frames for an address
```
         {
           "address": "0x1234",
           "frames": [
             {  
               "inlined": false,
               "shortFunctionName": "initWithString",
               "linkageFunctionName": "- [FooClass initWithString:]",
              "symbolTableFunctionName": "- [FooClass initWithString:]",
               "fileName": "FooClass.m",
               "startLine": 6,
               "line": 8,
               "column": 10,
               "discriminator": null
             },{
               ...
             }
           ]
         }
```

Additionally I found in testing that [this hack](https://github.com/bugsnag/llvm/commit/2863b3b3ee5dd15a202f9dc55230e7b724d07ffe) we are applying to remove compilation directory from filename was not being applied. I have copied this into SymbolizableObjectFile::symbolizeInlinedCode so that it is applied to all returned frames.

Tested with this [corresponding bugsnag-dsym change](https://github.com/bugsnag/bugsnag-dsym/pull/31) against event-worker tests locally and had no failures.