### PR TITLE
PIPE-10455: Fix Type Casting and Overflow Issue During Multiplication

### DIFF
--- a/include/llvm/CodeGen/PBQP/Math.h
+++ b/include/llvm/CodeGen/PBQP/Math.h
@@ -124,22 +124,22 @@ public:
 
   /// \brief Construct a PBQP Matrix with the given dimensions.
   Matrix(unsigned Rows, unsigned Cols) :
-    Rows(Rows), Cols(Cols), Data(llvm::make_unique<PBQPNum []>(Rows * Cols)) {
+    Rows(Rows), Cols(Cols), Data(llvm::make_unique<PBQPNum []>((size_t)Rows * Cols)) {
   }
 
   /// \brief Construct a PBQP Matrix with the given dimensions and initial
   /// value.
   Matrix(unsigned Rows, unsigned Cols, PBQPNum InitVal)
     : Rows(Rows), Cols(Cols),
-      Data(llvm::make_unique<PBQPNum []>(Rows * Cols)) {
-    std::fill(Data.get(), Data.get() + (Rows * Cols), InitVal);
+      Data(llvm::make_unique<PBQPNum []>((size_t)Rows * Cols)) {
+    std::fill(Data.get(), Data.get() + ((size_t)Rows * Cols), InitVal);
   }
 
   /// \brief Copy construct a PBQP matrix.
   Matrix(const Matrix &M)
     : Rows(M.Rows), Cols(M.Cols),
-      Data(llvm::make_unique<PBQPNum []>(Rows * Cols)) {
-    std::copy(M.Data.get(), M.Data.get() + (Rows * Cols), Data.get());
+      Data(llvm::make_unique<PBQPNum []>((size_t)Rows * Cols)) {
+    std::copy(M.Data.get(), M.Data.get() + ((size_t)Rows * Cols), Data.get());
   }
 
   /// \brief Move construct a PBQP matrix.
@@ -153,7 +153,7 @@ public:
     assert(Rows != 0 && Cols != 0 && Data && "Invalid matrix");
     if (Rows != M.Rows || Cols != M.Cols)
       return false;
-    return std::equal(Data.get(), Data.get() + (Rows * Cols), M.Data.get());
+    return std::equal(Data.get(), Data.get() + ((size_t)Rows * Cols), M.Data.get());
   }
 
   /// \brief Return the number of rows in this matrix.
@@ -172,14 +172,14 @@ public:
   PBQPNum* operator[](unsigned R) {
     assert(Rows != 0 && Cols != 0 && Data && "Invalid matrix");
     assert(R < Rows && "Row out of bounds.");
-    return Data.get() + (R * Cols);
+    return Data.get() + ((size_t)R * Cols);
   }
 
   /// \brief Matrix element access.
   const PBQPNum* operator[](unsigned R) const {
     assert(Rows != 0 && Cols != 0 && Data && "Invalid matrix");
     assert(R < Rows && "Row out of bounds.");
-    return Data.get() + (R * Cols);
+    return Data.get() + ((size_t)R * Cols);
   }
 
   /// \brief Returns the given row as a vector.
@@ -215,7 +215,7 @@ public:
     assert(Rows != 0 && Cols != 0 && Data && "Invalid matrix");
     assert(Rows == M.Rows && Cols == M.Cols &&
            "Matrix dimensions mismatch.");
-    std::transform(Data.get(), Data.get() + (Rows * Cols), M.Data.get(),
+    std::transform(Data.get(), Data.get() + ((size_t)Rows * Cols), M.Data.get(),
                    Data.get(), std::plus<PBQPNum>());
     return *this;
   }
@@ -236,7 +236,7 @@ private:
 inline hash_code hash_value(const Matrix &M) {
   unsigned *MBegin = reinterpret_cast<unsigned*>(M.Data.get());
   unsigned *MEnd =
-    reinterpret_cast<unsigned*>(M.Data.get() + (M.Rows * M.Cols));
+    reinterpret_cast<unsigned*>(M.Data.get() + ((size_t)M.Rows * M.Cols));
   return hash_combine(M.Rows, M.Cols, hash_combine_range(MBegin, MEnd));
 }
 

--- a/include/llvm/Support/raw_ostream.h
+++ b/include/llvm/Support/raw_ostream.h
@@ -69,6 +69,9 @@ private:
     ExternalBuffer
   } BufferMode;
 
+/// Flag to prevent virtual calls during construction/destruction.
+  bool IsInitialized = false;
+  
 public:
   // color order matches ANSI escape sequence, don't change
   enum Colors {

--- a/include/llvm/Support/raw_ostream.h
+++ b/include/llvm/Support/raw_ostream.h
@@ -69,7 +69,7 @@ private:
     ExternalBuffer
   } BufferMode;
 
-/// Flag to prevent virtual calls during construction/destruction.
+// Flag to prevent virtual calls during construction/destruction.
   bool IsInitialized = false;
   
 public:

--- a/lib/CodeGen/MachinePipeliner.cpp
+++ b/lib/CodeGen/MachinePipeliner.cpp
@@ -3098,7 +3098,7 @@ void SwingSchedulerDAG::updateMemOperands(MachineInstr &NewMI,
     }
     unsigned Delta;
     if (computeDelta(OldMI, Delta)) {
-      int64_t AdjOffset = Delta * Num;
+      int64_t AdjOffset = (int64_t)Delta * Num;
       NewMemRefs[Refs++] =
           MF.getMachineMemOperand(MMO, AdjOffset, MMO->getSize());
     } else

--- a/lib/CodeGen/MachineTraceMetrics.cpp
+++ b/lib/CodeGen/MachineTraceMetrics.cpp
@@ -71,7 +71,7 @@ bool MachineTraceMetrics::runOnMachineFunction(MachineFunction &Func) {
   Loops = &getAnalysis<MachineLoopInfo>();
   SchedModel.init(ST.getSchedModel(), &ST, TII);
   BlockInfo.resize(MF->getNumBlockIDs());
-  ProcResourceCycles.resize(MF->getNumBlockIDs() *
+  ProcResourceCycles.resize((uint64_t)MF->getNumBlockIDs() *
                             SchedModel.getNumProcResourceKinds());
   return false;
 }
@@ -145,8 +145,8 @@ MachineTraceMetrics::getProcResourceCycles(unsigned MBBNum) const {
   assert(BlockInfo[MBBNum].hasResources() &&
          "getResources() must be called before getProcResourceCycles()");
   unsigned PRKinds = SchedModel.getNumProcResourceKinds();
-  assert((MBBNum+1) * PRKinds <= ProcResourceCycles.size());
-  return makeArrayRef(ProcResourceCycles.data() + MBBNum * PRKinds, PRKinds);
+  assert((uint64_t)(MBBNum+1) * PRKinds <= ProcResourceCycles.size());
+  return makeArrayRef(ProcResourceCycles.data() + (uint64_t)MBBNum * PRKinds, PRKinds);
 }
 
 //===----------------------------------------------------------------------===//
@@ -264,8 +264,8 @@ ArrayRef<unsigned>
 MachineTraceMetrics::Ensemble::
 getProcResourceDepths(unsigned MBBNum) const {
   unsigned PRKinds = MTM.SchedModel.getNumProcResourceKinds();
-  assert((MBBNum+1) * PRKinds <= ProcResourceDepths.size());
-  return makeArrayRef(ProcResourceDepths.data() + MBBNum * PRKinds, PRKinds);
+  assert((uint64_t)(MBBNum+1) * PRKinds <= ProcResourceDepths.size());
+  return makeArrayRef(ProcResourceDepths.data() + (uint64_t)MBBNum * PRKinds, PRKinds);
 }
 
 /// Get an array of processor resource heights for MBB. Indexed by processor
@@ -277,8 +277,8 @@ ArrayRef<unsigned>
 MachineTraceMetrics::Ensemble::
 getProcResourceHeights(unsigned MBBNum) const {
   unsigned PRKinds = MTM.SchedModel.getNumProcResourceKinds();
-  assert((MBBNum+1) * PRKinds <= ProcResourceHeights.size());
-  return makeArrayRef(ProcResourceHeights.data() + MBBNum * PRKinds, PRKinds);
+  assert((uint64_t)(MBBNum+1) * PRKinds <= ProcResourceHeights.size());
+  return makeArrayRef(ProcResourceHeights.data() + (uint64_t)MBBNum * PRKinds, PRKinds);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -827,7 +827,7 @@ SDValue DAGTypeLegalizer::PromoteIntRes_VAARG(SDNode *N) {
     SDValue Part = DAG.getNode(ISD::ZERO_EXTEND, dl, NVT, Parts[i]);
     // Shift it to the right position and "or" it in.
     Part = DAG.getNode(ISD::SHL, dl, NVT, Part,
-                       DAG.getConstant(i * RegVT.getSizeInBits(), dl,
+                       DAG.getConstant(static_cast<uint64_t>(i) * RegVT.getSizeInBits(), dl,
                                        TLI.getPointerTy(DAG.getDataLayout())));
     Res = DAG.getNode(ISD::OR, dl, NVT, Res, Part);
   }

--- a/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -7357,7 +7357,7 @@ bool SelectionDAG::areNonVolatileConsecutiveLoads(LoadSDNode *LD,
     int FS  = MFI.getObjectSize(FI);
     int BFS = MFI.getObjectSize(BFI);
     if (FS != BFS || FS != (int)Bytes) return false;
-    return MFI.getObjectOffset(FI) == (MFI.getObjectOffset(BFI) + Dist*Bytes);
+    return MFI.getObjectOffset(FI) == (MFI.getObjectOffset(BFI) + (uint64_t)Dist*Bytes);
   }
 
   // Handle X + C.
@@ -7366,7 +7366,7 @@ bool SelectionDAG::areNonVolatileConsecutiveLoads(LoadSDNode *LD,
     if (Loc.getOperand(0) == BaseLoc) {
       // If the base location is a simple address with no offset itself, then
       // the second load's first add operand should be the base address.
-      if (LocOffset == Dist * (int)Bytes)
+      if (LocOffset == (uint64_t)Dist * (int)Bytes)
         return true;
     } else if (isBaseWithConstantOffset(BaseLoc)) {
       // The base location itself has an offset, so subtract that value from the
@@ -7374,7 +7374,7 @@ bool SelectionDAG::areNonVolatileConsecutiveLoads(LoadSDNode *LD,
       int64_t BOffset =
         cast<ConstantSDNode>(BaseLoc.getOperand(1))->getSExtValue();
       if (Loc.getOperand(0) == BaseLoc.getOperand(0)) {
-        if ((LocOffset - BOffset) == Dist * (int)Bytes)
+        if ((LocOffset - BOffset) == (uint64_t)Dist * (int)Bytes)
           return true;
       }
     }
@@ -7386,7 +7386,7 @@ bool SelectionDAG::areNonVolatileConsecutiveLoads(LoadSDNode *LD,
   bool isGA1 = TLI->isGAPlusOffset(Loc.getNode(), GV1, Offset1);
   bool isGA2 = TLI->isGAPlusOffset(BaseLoc.getNode(), GV2, Offset2);
   if (isGA1 && isGA2 && GV1 == GV2)
-    return Offset1 == (Offset2 + Dist*Bytes);
+    return Offset1 == (Offset2 + (uint64_t)Dist*Bytes);
   return false;
 }
 

--- a/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -588,7 +588,7 @@ static void getCopyToPartsVector(SelectionDAG &DAG, const SDLoc &DL,
     if (IntermediateVT.isVector())
       Ops[i] =
           DAG.getNode(ISD::EXTRACT_SUBVECTOR, DL, IntermediateVT, Val,
-                      DAG.getConstant(i * (NumElements / NumIntermediates), DL,
+                      DAG.getConstant((uint64_t)i * (NumElements / NumIntermediates), DL,
                                       TLI.getVectorIdxTy(DAG.getDataLayout())));
     else
       Ops[i] = DAG.getNode(

--- a/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -3397,8 +3397,8 @@ SDValue TargetLowering::scalarizeVectorLoad(LoadSDNode *LD,
   for (unsigned Idx = 0; Idx < NumElem; ++Idx) {
     SDValue ScalarLoad =
         DAG.getExtLoad(ExtType, SL, DstEltVT, Chain, BasePTR,
-                       LD->getPointerInfo().getWithOffset(Idx * Stride),
-                       SrcEltVT, MinAlign(LD->getAlignment(), Idx * Stride),
+                       LD->getPointerInfo().getWithOffset((uint64_t)Idx * Stride),
+                       MinAlign(LD->getAlignment(), (uint64_t)Idx * Stride),
                        LD->getMemOperand()->getFlags(), LD->getAAInfo());
 
     BasePTR = DAG.getNode(ISD::ADD, SL, PtrVT, BasePTR,
@@ -3448,12 +3448,12 @@ SDValue TargetLowering::scalarizeVectorStore(StoreSDNode *ST,
                               DAG.getConstant(Idx, SL, IdxVT));
 
     SDValue Ptr = DAG.getNode(ISD::ADD, SL, PtrVT, BasePtr,
-                              DAG.getConstant(Idx * Stride, SL, PtrVT));
+                              DAG.getConstant((uint64_t)Idx * Stride, SL, PtrVT));
 
     // This scalar TruncStore may be illegal, but we legalize it later.
     SDValue Store = DAG.getTruncStore(
-        Chain, SL, Elt, Ptr, ST->getPointerInfo().getWithOffset(Idx * Stride),
-        MemSclVT, MinAlign(ST->getAlignment(), Idx * Stride),
+        Chain, SL, Elt, Ptr, ST->getPointerInfo().getWithOffset((uint64_t)Idx * Stride),
+        MemSclVT, MinAlign(ST->getAlignment(), (uint64_t)Idx * Stride),
         ST->getMemOperand()->getFlags(), ST->getAAInfo());
 
     Stores.push_back(Store);

--- a/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -3398,7 +3398,7 @@ SDValue TargetLowering::scalarizeVectorLoad(LoadSDNode *LD,
     SDValue ScalarLoad =
         DAG.getExtLoad(ExtType, SL, DstEltVT, Chain, BasePTR,
                        LD->getPointerInfo().getWithOffset((uint64_t)Idx * Stride),
-                       MinAlign(LD->getAlignment(), (uint64_t)Idx * Stride),
+                       SrcEltVT, MinAlign(LD->getAlignment(), (uint64_t)Idx * Stride),
                        LD->getMemOperand()->getFlags(), LD->getAAInfo());
 
     BasePTR = DAG.getNode(ISD::ADD, SL, PtrVT, BasePTR,

--- a/lib/DebugInfo/PDB/Native/PDBFileBuilder.cpp
+++ b/lib/DebugInfo/PDB/Native/PDBFileBuilder.cpp
@@ -113,7 +113,7 @@ Error PDBFileBuilder::commit(StringRef Filename) {
     return ExpectedLayout.takeError();
   auto &Layout = *ExpectedLayout;
 
-  uint64_t Filesize = Layout.SB->BlockSize * Layout.SB->NumBlocks;
+  uint64_t Filesize = (uint64_t)Layout.SB->BlockSize * Layout.SB->NumBlocks;
   auto OutFileOrError = FileOutputBuffer::create(Filename, Filesize);
   if (OutFileOrError.getError())
     return llvm::make_error<pdb::GenericError>(generic_error_code::invalid_path,

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -357,7 +357,7 @@ void *ArgvArray::reset(LLVMContext &C, ExecutionEngine *EE,
 
     // Endian safe: Array[i] = (PointerTy)Dest;
     EE->StoreValueToMemory(PTOGV(Dest.get()),
-                           (GenericValue*)(&Array[i*PtrSize]), SBytePtr);
+                           (GenericValue*)(&Array[(uint64_t)i*PtrSize]), SBytePtr);
     Values.push_back(std::move(Dest));
   }
 

--- a/lib/Fuzzer/FuzzerCorpus.h
+++ b/lib/Fuzzer/FuzzerCorpus.h
@@ -114,7 +114,7 @@ class InputCorpus {
   void PrintFeatureSet() {
     for (size_t i = 0; i < kFeatureSetSize; i++) {
       if(size_t Sz = GetFeature(i))
-        Printf("[%zu: id %zu sz%zu] ", i, SmallestElementPerFeature[i], Sz);
+        Printf("[%zu: id %u sz%zu] ", i, SmallestElementPerFeature[i], Sz);
     }
     Printf("\n\t");
     for (size_t i = 0; i < Inputs.size(); i++)

--- a/lib/Fuzzer/FuzzerCorpus.h
+++ b/lib/Fuzzer/FuzzerCorpus.h
@@ -72,7 +72,7 @@ class InputCorpus {
     assert(!U.empty());
     uint8_t Hash[kSHA1NumBytes];
     if (FeatureDebug)
-      Printf("ADD_TO_CORPUS %zd NF %zd\n", Inputs.size(), NumFeatures);
+      Printf("ADD_TO_CORPUS %zu NF %zu\n", Inputs.size(), NumFeatures);
     ComputeSHA1(U.data(), U.size(), Hash);
     Hashes.insert(Sha1ToString(Hash));
     Inputs.push_back(new InputInfo());
@@ -105,7 +105,7 @@ class InputCorpus {
   void PrintStats() {
     for (size_t i = 0; i < Inputs.size(); i++) {
       const auto &II = *Inputs[i];
-      Printf("  [%zd %s]\tsz: %zd\truns: %zd\tsucc: %zd\n", i,
+      Printf("  [%zu %s]\tsz: %zu\truns: %zu\tsucc: %zu\n", i,
              Sha1ToString(II.Sha1).c_str(), II.U.size(),
              II.NumExecutedMutations, II.NumSuccessfullMutations);
     }
@@ -114,12 +114,12 @@ class InputCorpus {
   void PrintFeatureSet() {
     for (size_t i = 0; i < kFeatureSetSize; i++) {
       if(size_t Sz = GetFeature(i))
-        Printf("[%zd: id %zd sz%zd] ", i, SmallestElementPerFeature[i], Sz);
+        Printf("[%zu: id %zu sz%zu] ", i, SmallestElementPerFeature[i], Sz);
     }
     Printf("\n\t");
     for (size_t i = 0; i < Inputs.size(); i++)
       if (size_t N = Inputs[i]->NumFeatures)
-        Printf(" %zd=>%zd ", i, N);
+        Printf(" %zu=>%zu ", i, N);
     Printf("\n");
   }
 
@@ -129,7 +129,7 @@ class InputCorpus {
       RemoveFile(DirPlusFile(OutputCorpus, Sha1ToString(II.Sha1)));
     Unit().swap(II.U);
     if (FeatureDebug)
-      Printf("EVICTED %zd\n", Idx);
+      Printf("EVICTED %zu\n", Idx);
   }
 
   bool AddFeature(size_t Idx, uint32_t NewSize, bool Shrink) {
@@ -146,7 +146,7 @@ class InputCorpus {
           DeleteInput(OldIdx);
       }
       if (FeatureDebug)
-        Printf("ADD FEATURE %zd sz %d\n", Idx, NewSize);
+        Printf("ADD FEATURE %zu sz %u\n", Idx, NewSize);
       SmallestElementPerFeature[Idx] = Inputs.size();
       InputSizesPerFeature[Idx] = NewSize;
       CountingFeatures = true;

--- a/lib/Support/Unix/Signals.inc
+++ b/lib/Support/Unix/Signals.inc
@@ -190,21 +190,27 @@ static void RemoveFilesToRemove() {
   std::vector<std::string>& FilesToRemoveRef = *FilesToRemove;
   for (unsigned i = 0, e = FilesToRemoveRef.size(); i != e; ++i) {
     const char *path = FilesToRemoveRef[i].c_str();
-
-    // Get the status so we can determine if it's a file or directory. If we
-    // can't stat the file, ignore it.
-    struct stat buf;
-    if (stat(path, &buf) != 0)
+    // Open with O_NOFOLLOW to refuse symlinks, eliminating the
+    // TOCTOU race between check and unlink (CWE-367).
+    int fd = open(path, O_RDONLY | O_NOFOLLOW);
+    if (fd < 0)
       continue;
-
+    // fstat() operates on the opened fd, not the path — no race window.
+    struct stat buf;
+    if (fstat(fd, &buf) != 0) {
+      close(fd);
+      continue;
+    }
     // If this is not a regular file, ignore it. We want to prevent removal of
     // special files like /dev/null, even if the compiler is being run with the
     // super-user permissions.
-    if (!S_ISREG(buf.st_mode))
+    if (!S_ISREG(buf.st_mode)) {
+      close(fd);
       continue;
-
-    // Otherwise, remove the file. We ignore any errors here as there is nothing
-    // else we can do.
+    }
+    close(fd);
+    // Safe to unlink — we confirmed via fd that the path pointed to a regular
+    // file and O_NOFOLLOW ensured no symlink was followed.
     unlink(path);
   }
 }

--- a/lib/Support/raw_ostream.cpp
+++ b/lib/Support/raw_ostream.cpp
@@ -69,6 +69,8 @@
 using namespace llvm;
 
 raw_ostream::~raw_ostream() {
+    // Mark object as destructing to prevent virtual calls
+  IsInitialized = false;
   // raw_ostream's subclasses should take care to flush the buffer
   // in their destructors.
   assert(OutBufCur == OutBufStart &&
@@ -110,6 +112,9 @@ void raw_ostream::SetBufferAndMode(char *BufferStart, size_t Size,
   OutBufEnd = OutBufStart+Size;
   OutBufCur = OutBufStart;
   BufferMode = Mode;
+
+  // Mark as initialized after successful setup
+  IsInitialized = true;
 
   assert(OutBufStart <= OutBufEnd && "Invalid size!");
 }
@@ -193,7 +198,9 @@ void raw_ostream::flush_nonempty() {
   assert(OutBufCur > OutBufStart && "Invalid call to flush_nonempty.");
   size_t Length = OutBufCur - OutBufStart;
   OutBufCur = OutBufStart;
-  if (LLVM_LIKELY(Length > 0)){
+  // Only call write_impl if object is fully initialized and not destructing.
+  // This prevents pure virtual function calls during construction/destruction.
+  if (LLVM_LIKELY(IsInitialized)) {
     write_impl(OutBufStart, Length);
   }
 }

--- a/lib/Support/raw_ostream.cpp
+++ b/lib/Support/raw_ostream.cpp
@@ -193,7 +193,9 @@ void raw_ostream::flush_nonempty() {
   assert(OutBufCur > OutBufStart && "Invalid call to flush_nonempty.");
   size_t Length = OutBufCur - OutBufStart;
   OutBufCur = OutBufStart;
-  write_impl(OutBufStart, Length);
+  if (LLVM_LIKELY(Length > 0)){
+    write_impl(OutBufStart, Length);
+  }
 }
 
 raw_ostream &raw_ostream::write(unsigned char C) {

--- a/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -605,7 +605,7 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
   }
 
   unsigned LDSSpillSize =
-    MFI->LDSWaveSpillSize * MFI->getMaxFlatWorkGroupSize();
+    (uint64_t)MFI->LDSWaveSpillSize * MFI->getMaxFlatWorkGroupSize();
 
   ProgInfo.LDSSize = MFI->getLDSSize() + LDSSpillSize;
   ProgInfo.LDSBlocks =
@@ -617,7 +617,7 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
   // is used by the entire wave.  ProgInfo.ScratchSize is the amount of
   // scratch memory used per thread.
   ProgInfo.ScratchBlocks =
-      alignTo(ProgInfo.ScratchSize * STM.getWavefrontSize(),
+      alignTo((uint64_t)ProgInfo.ScratchSize * STM.getWavefrontSize(),
               1ULL << ScratchAlignShift) >>
       ScratchAlignShift;
 

--- a/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -641,10 +641,10 @@ bool SIRegisterInfo::spillSGPR(MachineBasicBlock::iterator MI,
 
       unsigned Align = FrameInfo.getObjectAlignment(Index);
       MachinePointerInfo PtrInfo
-        = MachinePointerInfo::getFixedStack(*MF, Index, EltSize * i);
+        = MachinePointerInfo::getFixedStack(*MF, Index, (uint64_t)EltSize * i);
       MachineMemOperand *MMO
         = MF->getMachineMemOperand(PtrInfo, MachineMemOperand::MOStore,
-                                   EltSize, MinAlign(Align, EltSize * i));
+                                   EltSize, MinAlign(Align, (uint64_t)EltSize * i));
 
       // SMEM instructions only support a single offset, so increment the wave
       // offset.
@@ -708,10 +708,10 @@ bool SIRegisterInfo::spillSGPR(MachineBasicBlock::iterator MI,
 
       unsigned Align = FrameInfo.getObjectAlignment(Index);
       MachinePointerInfo PtrInfo
-        = MachinePointerInfo::getFixedStack(*MF, Index, EltSize * i);
+        = MachinePointerInfo::getFixedStack(*MF, Index, (uint64_t)EltSize * i);
       MachineMemOperand *MMO
         = MF->getMachineMemOperand(PtrInfo, MachineMemOperand::MOStore,
-                                   EltSize, MinAlign(Align, EltSize * i));
+                                   EltSize, MinAlign(Align, (uint64_t)EltSize * i));
       BuildMI(*MBB, MI, DL, TII->get(AMDGPU::SI_SPILL_V32_SAVE))
         .addReg(TmpReg, RegState::Kill)         // src
         .addFrameIndex(Index)                   // vaddr
@@ -794,10 +794,10 @@ bool SIRegisterInfo::restoreSGPR(MachineBasicBlock::iterator MI,
       // FIXME: Size may be > 4 but extra bytes wasted.
       unsigned Align = FrameInfo.getObjectAlignment(Index);
       MachinePointerInfo PtrInfo
-        = MachinePointerInfo::getFixedStack(*MF, Index, EltSize * i);
+        = MachinePointerInfo::getFixedStack(*MF, Index, (uint64_t)EltSize * i);
       MachineMemOperand *MMO
         = MF->getMachineMemOperand(PtrInfo, MachineMemOperand::MOLoad,
-                                   EltSize, MinAlign(Align, EltSize * i));
+                                   EltSize, MinAlign(Align, (uint64_t)EltSize * i));
 
       // Add i * 4 offset
       int64_t Offset = (ST.getWavefrontSize() * FrOffset) + (EltSize * i);
@@ -843,11 +843,11 @@ bool SIRegisterInfo::restoreSGPR(MachineBasicBlock::iterator MI,
       unsigned Align = FrameInfo.getObjectAlignment(Index);
 
       MachinePointerInfo PtrInfo
-        = MachinePointerInfo::getFixedStack(*MF, Index, EltSize * i);
+        = MachinePointerInfo::getFixedStack(*MF, Index, (uint64_t)EltSize * i);
 
       MachineMemOperand *MMO = MF->getMachineMemOperand(PtrInfo,
         MachineMemOperand::MOLoad, EltSize,
-        MinAlign(Align, EltSize * i));
+        MinAlign(Align, (uint64_t)EltSize * i));
 
       BuildMI(*MBB, MI, DL, TII->get(AMDGPU::SI_SPILL_V32_RESTORE), TmpReg)
         .addFrameIndex(Index)                   // vaddr

--- a/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
+++ b/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
@@ -473,7 +473,7 @@ void ARMLoadStoreOpt::UpdateBaseRegUses(MachineBasicBlock &MBB,
         MachineOperand &MO =
           MBBI->getOperand(MBBI->getDesc().getNumOperands() - 3);
         // The offsets are scaled by 1, 2 or 4 depending on the Opcode.
-        Offset = MO.getImm() - WordOffset * getImmScale(Opc);
+        Offset = MO.getImm() - (int64_t)WordOffset * getImmScale(Opc);
 
         // If storing the base register, it needs to be reset first.
         unsigned InstrSrcReg = getLoadStoreRegOp(*MBBI).getReg();
@@ -491,8 +491,8 @@ void ARMLoadStoreOpt::UpdateBaseRegUses(MachineBasicBlock &MBB,
         MachineOperand &MO =
           MBBI->getOperand(MBBI->getDesc().getNumOperands() - 3);
         Offset = (Opc == ARM::tSUBi8) ?
-          MO.getImm() + WordOffset * 4 :
-          MO.getImm() - WordOffset * 4 ;
+          MO.getImm() + (int64_t)WordOffset * 4 :
+          MO.getImm() - (int64_t)WordOffset * 4 ;
         if (Offset >= 0 && TL->isLegalAddImmediate(Offset)) {
           // FIXME: Swap ADDS<->SUBS if Offset < 0, erase instruction if
           // Offset == 0.

--- a/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
+++ b/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
@@ -1390,7 +1390,7 @@ void ARMELFStreamer::emitRegSave(const SmallVectorImpl<unsigned> &RegList,
   // corresponding push instruction will decrease the $sp by (4 * Count).
   // For the .vsave directive, the corresponding vpush instruction will
   // decrease $sp by (8 * Count).
-  SPOffset -= Count * (IsVector ? 8 : 4);
+  SPOffset -= (int64_t)Count * (IsVector ? 8 : 4);
 
   // Emit the opcode
   FlushPendingOffset();

--- a/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -188,7 +188,7 @@ static void ComputePTXValueVTs(const TargetLowering &TLI, const DataLayout &DL,
       for (unsigned j = 0; j != NumElts; ++j) {
         ValueVTs.push_back(EltVT);
         if (Offsets)
-          Offsets->push_back(Off + j * EltVT.getStoreSize());
+          Offsets->push_back(Off + (uint64_t)j * EltVT.getStoreSize());
       }
     } else {
       ValueVTs.push_back(VT);
@@ -229,7 +229,7 @@ static unsigned CanMergeParamLoadStoresStartingAt(
 
   unsigned NumElts = AccessSize / EltSize;
   // Can't vectorize if AccessBytes if not a multiple of EltSize.
-  if (AccessSize != EltSize * NumElts)
+  if (AccessSize != (uint32_t)EltSize * NumElts)
     return 1;
 
   // We don't have enough elements to vectorize.

--- a/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -8417,12 +8417,12 @@ SDValue PPCTargetLowering::LowerVectorStore(SDValue Op,
       if (ScalarVT != ScalarMemVT)
         Store =
             DAG.getTruncStore(StoreChain, dl, Ex, BasePtr,
-                              SN->getPointerInfo().getWithOffset( (uint64_t)Idx * Stride),
+                              SN->getPointerInfo().getWithOffset((uint64_t)Idx * Stride),
                               ScalarMemVT, MinAlign(Alignment,  (uint64_t)Idx * Stride),
                               SN->getMemOperand()->getFlags(), SN->getAAInfo());
       else
         Store = DAG.getStore(StoreChain, dl, Ex, BasePtr,
-                             SN->getPointerInfo().getWithOffset( (uint64_t)Idx * Stride),
+                             SN->getPointerInfo().getWithOffset((uint64_t)Idx * Stride),
                              MinAlign(Alignment,  (uint64_t)Idx * Stride),
                              SN->getMemOperand()->getFlags(), SN->getAAInfo());
 

--- a/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -8325,13 +8325,13 @@ SDValue PPCTargetLowering::LowerVectorLoad(SDValue Op,
       if (ScalarVT != ScalarMemVT)
         Load = DAG.getExtLoad(LN->getExtensionType(), dl, ScalarVT, LoadChain,
                               BasePtr,
-                              LN->getPointerInfo().getWithOffset(Idx * Stride),
-                              ScalarMemVT, MinAlign(Alignment, Idx * Stride),
+                              LN->getPointerInfo().getWithOffset((uint64_t)Idx * Stride),
+                              ScalarMemVT, MinAlign(Alignment, (uint64_t)Idx * Stride),
                               LN->getMemOperand()->getFlags(), LN->getAAInfo());
       else
         Load = DAG.getLoad(ScalarVT, dl, LoadChain, BasePtr,
-                           LN->getPointerInfo().getWithOffset(Idx * Stride),
-                           MinAlign(Alignment, Idx * Stride),
+                           LN->getPointerInfo().getWithOffset((uint64_t)Idx * Stride),
+                           MinAlign(Alignment, (uint64_t)Idx * Stride),
                            LN->getMemOperand()->getFlags(), LN->getAAInfo());
 
       if (Idx == 0 && LN->isIndexed()) {
@@ -8417,13 +8417,13 @@ SDValue PPCTargetLowering::LowerVectorStore(SDValue Op,
       if (ScalarVT != ScalarMemVT)
         Store =
             DAG.getTruncStore(StoreChain, dl, Ex, BasePtr,
-                              SN->getPointerInfo().getWithOffset(Idx * Stride),
-                              ScalarMemVT, MinAlign(Alignment, Idx * Stride),
+                              SN->getPointerInfo().getWithOffset( (uint64_t)Idx * Stride),
+                              ScalarMemVT, MinAlign(Alignment,  (uint64_t)Idx * Stride),
                               SN->getMemOperand()->getFlags(), SN->getAAInfo());
       else
         Store = DAG.getStore(StoreChain, dl, Ex, BasePtr,
-                             SN->getPointerInfo().getWithOffset(Idx * Stride),
-                             MinAlign(Alignment, Idx * Stride),
+                             SN->getPointerInfo().getWithOffset( (uint64_t)Idx * Stride),
+                             MinAlign(Alignment,  (uint64_t)Idx * Stride),
                              SN->getMemOperand()->getFlags(), SN->getAAInfo());
 
       if (Idx == 0 && SN->isIndexed()) {
@@ -9995,14 +9995,14 @@ static bool isConsecutiveLSLoc(SDValue Loc, EVT VT, LSBaseSDNode *Base,
     int FS  = MFI.getObjectSize(FI);
     int BFS = MFI.getObjectSize(BFI);
     if (FS != BFS || FS != (int)Bytes) return false;
-    return MFI.getObjectOffset(FI) == (MFI.getObjectOffset(BFI) + Dist*Bytes);
+    return MFI.getObjectOffset(FI) == (MFI.getObjectOffset(BFI) + (uint64_t)Dist*Bytes);
   }
 
   SDValue Base1 = Loc, Base2 = BaseLoc;
   int64_t Offset1 = 0, Offset2 = 0;
   getBaseWithConstantOffset(Loc, Base1, Offset1, DAG);
   getBaseWithConstantOffset(BaseLoc, Base2, Offset2, DAG);
-  if (Base1 == Base2 && Offset1 == (Offset2 + Dist * Bytes))
+  if (Base1 == Base2 && Offset1 == (Offset2 + (uint64_t)Dist * Bytes))
     return true;
 
   const TargetLowering &TLI = DAG.getTargetLoweringInfo();
@@ -10013,7 +10013,7 @@ static bool isConsecutiveLSLoc(SDValue Loc, EVT VT, LSBaseSDNode *Base,
   bool isGA1 = TLI.isGAPlusOffset(Loc.getNode(), GV1, Offset1);
   bool isGA2 = TLI.isGAPlusOffset(BaseLoc.getNode(), GV2, Offset2);
   if (isGA1 && isGA2 && GV1 == GV2)
-    return Offset1 == (Offset2 + Dist*Bytes);
+    return Offset1 == (Offset2 + (uint64_t)Dist*Bytes);
   return false;
 }
 

--- a/lib/Target/X86/X86CallLowering.cpp
+++ b/lib/Target/X86/X86CallLowering.cpp
@@ -62,7 +62,7 @@ void X86CallLowering::splitToValueTypes(const ArgInfo &OrigArg,
         ArgInfo{MRI.createGenericVirtualRegister(getLLTForType(*PartTy, DL)),
                 PartTy, OrigArg.Flags};
     SplitArgs.push_back(Info);
-    PerformArgSplit(Info.Reg, PartVT.getSizeInBits() * i);
+    PerformArgSplit(Info.Reg, (uint64_t)PartVT.getSizeInBits() * i);
   }
 }
 

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -4696,7 +4696,7 @@ static void scaleShuffleMask(int Scale, ArrayRef<int> Mask,
                              SmallVectorImpl<int> &ScaledMask) {
   assert(0 < Scale && "Unexpected scaling factor");
   int NumElts = Mask.size();
-  ScaledMask.assign(NumElts * Scale, -1);
+  ScaledMask.assign((size_t)NumElts * Scale, -1);
 
   for (int i = 0; i != NumElts; ++i) {
     int M = Mask[i];
@@ -7840,7 +7840,7 @@ static SDValue LowerCONCAT_VECTORSvXi1(SDValue Op,
     if (NumOfDefinedOps == 1) {
       unsigned SubVecNumElts =
         Op.getOperand(OpIdx).getValueType().getVectorNumElements();
-      SDValue IdxVal = DAG.getIntPtrConstant(SubVecNumElts * OpIdx, dl);
+      SDValue IdxVal = DAG.getIntPtrConstant((uint64_t)SubVecNumElts * OpIdx, dl);
       return DAG.getNode(ISD::INSERT_SUBVECTOR, dl, ResVT, Undef,
                          Op.getOperand(OpIdx), IdxVal);
     }
@@ -9664,7 +9664,7 @@ static SDValue lowerVectorShuffleAsTruncBroadcast(const SDLoc &DL, MVT VT,
   // vpbroadcast+vmovd+shr to vpshufb(m)+vmovd.
   if (const int OffsetIdx = BroadcastIdx % Scale)
     Scalar = DAG.getNode(ISD::SRL, DL, Scalar.getValueType(), Scalar,
-            DAG.getConstant(OffsetIdx * EltSize, DL, Scalar.getValueType()));
+            DAG.getConstant((uint64_t)OffsetIdx * EltSize, DL, Scalar.getValueType()));
 
   return DAG.getNode(X86ISD::VBROADCAST, DL, VT,
                      DAG.getNode(ISD::TRUNCATE, DL, EltVT, Scalar));
@@ -18140,9 +18140,9 @@ static SDValue LowerExtendedLoad(SDValue Op, const X86Subtarget &Subtarget,
   }
 
   // Redistribute the loaded elements into the different locations.
-  SmallVector<int, 16> ShuffleVec(NumElems * SizeRatio, -1);
+  SmallVector<int, 16> ShuffleVec((size_t)NumElems * SizeRatio, -1);
   for (unsigned i = 0; i != NumElems; ++i)
-    ShuffleVec[i * SizeRatio] = i;
+    ShuffleVec[(size_t)i * SizeRatio] = i;
 
   SDValue Shuff = DAG.getVectorShuffle(WideVecVT, dl, SlicedVec,
                                        DAG.getUNDEF(WideVecVT), ShuffleVec);
@@ -26496,7 +26496,7 @@ static bool matchUnaryVectorShuffle(MVT MaskVT, ArrayRef<int> Mask,
       bool Match = true;
       unsigned NumDstElts = NumMaskElts / Scale;
       for (unsigned i = 0; i != NumDstElts && Match; ++i) {
-        Match &= isUndefOrEqual(Mask[i * Scale], (int)i);
+        Match &= isUndefOrEqual(Mask[(size_t)i * Scale], (int)i);
         Match &= isUndefOrZeroInRange(Mask, (i * Scale) + 1, Scale - 1);
       }
       if (Match) {
@@ -29165,7 +29165,7 @@ static SDValue combineExtractVectorElt(SDNode *N, SelectionDAG &DAG,
 
     // Replace each use (extract) with a load of the appropriate element.
     for (unsigned i = 0; i < 4; ++i) {
-      uint64_t Offset = EltSize * i;
+      uint64_t Offset = (uint64_t)EltSize * i;
       auto PtrVT = TLI.getPointerTy(DAG.getDataLayout());
       SDValue OffsetVal = DAG.getConstant(Offset, dl, PtrVT);
 
@@ -32153,9 +32153,9 @@ static SDValue combineMaskedLoad(SDNode *N, SelectionDAG &DAG,
   // Convert Src0 value.
   SDValue WideSrc0 = DAG.getBitcast(WideVecVT, Mld->getSrc0());
   if (!Mld->getSrc0().isUndef()) {
-    SmallVector<int, 16> ShuffleVec(NumElems * SizeRatio, -1);
+    SmallVector<int, 16> ShuffleVec((size_t)NumElems * SizeRatio, -1);
     for (unsigned i = 0; i != NumElems; ++i)
-      ShuffleVec[i] = i * SizeRatio;
+      ShuffleVec[i] = (size_t)i * SizeRatio;
 
     // Can't shuffle using an illegal type.
     assert(DAG.getTargetLoweringInfo().isTypeLegal(WideVecVT) &&
@@ -32169,9 +32169,9 @@ static SDValue combineMaskedLoad(SDNode *N, SelectionDAG &DAG,
   if (Mask.getValueType() == VT) {
     // Mask and original value have the same type.
     NewMask = DAG.getBitcast(WideVecVT, Mask);
-    SmallVector<int, 16> ShuffleVec(NumElems * SizeRatio, -1);
+    SmallVector<int, 16> ShuffleVec((size_t)NumElems * SizeRatio, -1);
     for (unsigned i = 0; i != NumElems; ++i)
-      ShuffleVec[i] = i * SizeRatio;
+      ShuffleVec[i] = (size_t)i * SizeRatio;
     for (unsigned i = NumElems; i != NumElems * SizeRatio; ++i)
       ShuffleVec[i] = NumElems * SizeRatio;
     NewMask = DAG.getVectorShuffle(WideVecVT, dl, NewMask,
@@ -32276,9 +32276,9 @@ static SDValue combineMaskedStore(SDNode *N, SelectionDAG &DAG,
   assert(WideVecVT.getSizeInBits() == VT.getSizeInBits());
 
   SDValue WideVec = DAG.getBitcast(WideVecVT, Mst->getValue());
-  SmallVector<int, 16> ShuffleVec(NumElems * SizeRatio, -1);
+  SmallVector<int, 16> ShuffleVec((size_t)NumElems * SizeRatio, -1);
   for (unsigned i = 0; i != NumElems; ++i)
-    ShuffleVec[i] = i * SizeRatio;
+    ShuffleVec[i] = (size_t)i * SizeRatio;
 
   // Can't shuffle using an illegal type.
   assert(DAG.getTargetLoweringInfo().isTypeLegal(WideVecVT) &&
@@ -32408,9 +32408,9 @@ static SDValue combineStore(SDNode *N, SelectionDAG &DAG,
     assert(WideVecVT.getSizeInBits() == VT.getSizeInBits());
 
     SDValue WideVec = DAG.getBitcast(WideVecVT, St->getValue());
-    SmallVector<int, 8> ShuffleVec(NumElems * SizeRatio, -1);
+    SmallVector<int, 8> ShuffleVec((size_t)NumElems * SizeRatio, -1);
     for (unsigned i = 0; i != NumElems; ++i)
-      ShuffleVec[i] = i * SizeRatio;
+      ShuffleVec[i] = (size_t)i * SizeRatio;
 
     // Can't shuffle using an illegal type.
     if (!TLI.isTypeLegal(WideVecVT))
@@ -32949,7 +32949,7 @@ static SDValue combineVectorTruncation(SDNode *N, SelectionDAG &DAG,
 
   for (unsigned i = 0; i < RegNum; i++)
     SubVec[i] = DAG.getNode(ISD::EXTRACT_SUBVECTOR, DL, SubRegVT, In,
-                            DAG.getIntPtrConstant(i * NumSubRegElts, DL));
+                            DAG.getIntPtrConstant((uint64_t)i * NumSubRegElts, DL));
 
   // SSE2 provides PACKUS for only 2 x v8i16 -> v16i8 and SSE4.1 provides PACKUS
   // for 2 x v4i32 -> v8i16. For SSSE3 and below, we need to use PACKSS to

--- a/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -1136,7 +1136,7 @@ void LowerTypeTestsModule::buildBitSetsFromFunctionsNative(
   DenseMap<GlobalTypeMember *, uint64_t> GlobalLayout;
   unsigned EntrySize = getJumpTableEntrySize();
   for (unsigned I = 0; I != Functions.size(); ++I)
-    GlobalLayout[Functions[I]] = I * EntrySize;
+    GlobalLayout[Functions[I]] = (uint64_t)I * EntrySize;
 
   Function *JumpTableFn =
       Function::Create(FunctionType::get(Type::getVoidTy(M.getContext()),

--- a/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -1041,7 +1041,7 @@ static Value *simplifyX86vpermilvar(const IntrinsicInst &II,
     // The _256 variants are a bit trickier since the mask bits always index
     // into the corresponding 128 half. In order to convert to a generic
     // shuffle, we have to make that explicit.
-    Index += APInt(32, (I / NumLaneElts) * NumLaneElts);
+    Index += APInt(32, ((uint64_t)I / NumLaneElts) * NumLaneElts);
 
     Indexes[I] = ConstantInt::get(MaskEltTy, Index);
   }

--- a/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -366,8 +366,14 @@ void IndVarSimplify::handleFloatingPointIV(Loop *L, PHINode *PN) {
 
     // If the stride would wrap around the i32 before exiting, we can't
     // transform the IV.
-    if (Leftover != 0 && int32_t(ExitValue+IncValue) < ExitValue)
-      return;
+    if (Leftover != 0) {
+      int64_t Sum = (int64_t)ExitValue + (int64_t)IncValue;
+      // Check if Sum fits in int32_t before comparing
+      if (Sum > INT32_MAX || Sum < INT32_MIN)
+        return;
+      if ((int32_t)Sum < (int32_t)ExitValue)
+        return;
+    }
 
   } else {
     // If we have a negative stride, we require the init to be greater than the
@@ -393,8 +399,14 @@ void IndVarSimplify::handleFloatingPointIV(Loop *L, PHINode *PN) {
 
     // If the stride would wrap around the i32 before exiting, we can't
     // transform the IV.
-    if (Leftover != 0 && int32_t(ExitValue+IncValue) > ExitValue)
-      return;
+    if (Leftover != 0) {
+      int64_t Sum = ExitValue + IncValue;
+      // Check if Sum fits in int32_t before casting
+      if (Sum > INT32_MAX || Sum < INT32_MIN)
+        return;
+      if (int32_t(Sum) > (int32_t)ExitValue)
+        return;
+    }
   }
 
   IntegerType *Int32Ty = Type::getInt32Ty(PN->getContext());

--- a/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -3277,7 +3277,7 @@ Value *InnerLoopVectorizer::getOrCreateVectorTripCount(Loop *L) {
   // iterations are not required for correctness, or N - Step, otherwise. Step
   // is equal to the vectorization factor (number of SIMD elements) times the
   // unroll factor (number of SIMD instructions).
-  Constant *Step = ConstantInt::get(TC->getType(), VF * UF);
+  Constant *Step = ConstantInt::get(TC->getType(), (uint64_t)VF * UF);
   Value *R = Builder.CreateURem(TC, Step, "n.mod.vf");
 
   // If there is a non-reversed interleaved group that may speculatively access
@@ -3306,7 +3306,7 @@ void InnerLoopVectorizer::emitMinimumIterationCountCheck(Loop *L,
   // Generate code to check that the loop's trip count that we computed by
   // adding one to the backedge-taken count will not overflow.
   Value *CheckMinIters = Builder.CreateICmpULT(
-      Count, ConstantInt::get(Count->getType(), VF * UF), "min.iters.check");
+      Count, ConstantInt::get(Count->getType(), (uint64_t)VF * UF), "min.iters.check");
 
   BasicBlock *NewBB =
       BB->splitBasicBlock(BB->getTerminator(), "min.iters.checked");
@@ -3512,7 +3512,7 @@ void InnerLoopVectorizer::createEmptyLoop() {
   // The loop step is equal to the vectorization factor (num of SIMD elements)
   // times the unroll factor (num of SIMD instructions).
   Value *CountRoundDown = getOrCreateVectorTripCount(Lp);
-  Constant *Step = ConstantInt::get(IdxTy, VF * UF);
+  Constant *Step = ConstantInt::get(IdxTy, (uint64_t)VF * UF);
   Induction =
       createInductionVariable(Lp, StartIdx, CountRoundDown, Step,
                               getDebugLocFromInstOrOperands(OldInduction));

--- a/tools/llvm-objdump/MachODump.cpp
+++ b/tools/llvm-objdump/MachODump.cpp
@@ -343,7 +343,6 @@ static void PrintIndirectSymbolTable(MachOObjectFile *O, bool verbose,
       outs() << format("0x%016" PRIx64, addr + (uint64_t)j * stride) << " ";
     else
       outs() << format("0x%08" PRIx32, (uint32_t)(addr + (uint64_t)j * stride)) << " ";
-    MachO::dysymtab_command Dysymtab = O->getDysymtabLoadCommand();
     uint32_t indirect_symbol = O->getIndirectSymbolTableEntry(Dysymtab, n + j);
     if (indirect_symbol == MachO::INDIRECT_SYMBOL_LOCAL) {
       outs() << "LOCAL\n";
@@ -7055,7 +7054,7 @@ printMachOCompactUnwindSection(const MachOObjectFile *Obj,
     uint64_t RelocAddress = Reloc.getOffset();
 
     uint32_t EntryIdx = RelocAddress / EntrySize;
-    uint32_t OffsetInEntry = RelocAddress - (uint64_t)EntryIdx * EntrySize;
+    uint64_t OffsetInEntry = RelocAddress - (uint64_t)EntryIdx * EntrySize;
     CompactUnwindEntry &Entry = CompactUnwinds[EntryIdx];
 
     if (OffsetInEntry == 0)

--- a/tools/llvm-objdump/MachODump.cpp
+++ b/tools/llvm-objdump/MachODump.cpp
@@ -340,9 +340,9 @@ static void PrintIndirectSymbolTable(MachOObjectFile *O, bool verbose,
     outs() << "\n";
   for (uint32_t j = 0; j < count && n + j < nindirectsyms; j++) {
     if (cputype & MachO::CPU_ARCH_ABI64)
-      outs() << format("0x%016" PRIx64, addr + j * stride) << " ";
+      outs() << format("0x%016" PRIx64, addr + (uint64_t)j * stride) << " ";
     else
-      outs() << format("0x%08" PRIx32, (uint32_t)addr + j * stride) << " ";
+      outs() << format("0x%08" PRIx32, (uint32_t)(addr + (uint64_t)j * stride)) << " ";
     MachO::dysymtab_command Dysymtab = O->getDysymtabLoadCommand();
     uint32_t indirect_symbol = O->getIndirectSymbolTableEntry(Dysymtab, n + j);
     if (indirect_symbol == MachO::INDIRECT_SYMBOL_LOCAL) {
@@ -937,7 +937,7 @@ static void DumpInitTermPointerSection(MachOObjectFile *O, const char *sect,
   for (uint32_t i = 0; i < sect_size; i += stride) {
     const char *SymbolName = nullptr;
     if (O->is64Bit()) {
-      outs() << format("0x%016" PRIx64, sect_addr + i * stride) << " ";
+      outs() << format("0x%016" PRIx64, sect_addr + (uint64_t)i * stride) << " ";
       uint64_t pointer_value;
       memcpy(&pointer_value, sect + i, stride);
       if (O->isLittleEndian() != sys::IsLittleEndianHost)
@@ -946,7 +946,7 @@ static void DumpInitTermPointerSection(MachOObjectFile *O, const char *sect,
       if (verbose)
         SymbolName = GuessSymbolName(pointer_value, AddrMap);
     } else {
-      outs() << format("0x%08" PRIx64, sect_addr + i * stride) << " ";
+      outs() << format("0x%08" PRIx64, sect_addr + (uint64_t)i * stride) << " ";
       uint32_t pointer_value;
       memcpy(&pointer_value, sect + i, stride);
       if (O->isLittleEndian() != sys::IsLittleEndianHost)
@@ -7055,7 +7055,7 @@ printMachOCompactUnwindSection(const MachOObjectFile *Obj,
     uint64_t RelocAddress = Reloc.getOffset();
 
     uint32_t EntryIdx = RelocAddress / EntrySize;
-    uint32_t OffsetInEntry = RelocAddress - EntryIdx * EntrySize;
+    uint32_t OffsetInEntry = RelocAddress - (uint64_t)EntryIdx * EntrySize;
     CompactUnwindEntry &Entry = CompactUnwinds[EntryIdx];
 
     if (OffsetInEntry == 0)

--- a/tools/llvm-objdump/MachODump.cpp
+++ b/tools/llvm-objdump/MachODump.cpp
@@ -7054,7 +7054,12 @@ printMachOCompactUnwindSection(const MachOObjectFile *Obj,
     uint64_t RelocAddress = Reloc.getOffset();
 
     uint32_t EntryIdx = RelocAddress / EntrySize;
-    uint64_t OffsetInEntry = RelocAddress - (uint64_t)EntryIdx * EntrySize;
+    uint32_t OffsetInEntry = RelocAddress - (uint64_t)EntryIdx * EntrySize;
+    if (EntryIdx >= CompactUnwinds.size()) 
+    {
+      outs() << "Invalid relocation in __compact_unwind section\n";
+      return;
+    }
     CompactUnwindEntry &Entry = CompactUnwinds[EntryIdx];
 
     if (OffsetInEntry == 0)

--- a/tools/llvm-objdump/MachODump.cpp
+++ b/tools/llvm-objdump/MachODump.cpp
@@ -7055,8 +7055,7 @@ printMachOCompactUnwindSection(const MachOObjectFile *Obj,
 
     uint32_t EntryIdx = RelocAddress / EntrySize;
     uint32_t OffsetInEntry = RelocAddress - (uint64_t)EntryIdx * EntrySize;
-    if (EntryIdx >= CompactUnwinds.size()) 
-    {
+    if (EntryIdx >= CompactUnwinds.size()) {
       outs() << "Invalid relocation in __compact_unwind section\n";
       return;
     }

--- a/tools/llvm-pdbdump/LLVMOutputStyle.cpp
+++ b/tools/llvm-pdbdump/LLVMOutputStyle.cpp
@@ -200,7 +200,7 @@ void LLVMOutputStyle::discoverStreamPurposes() {
   }
 
   StreamPurposes.resize(StreamCount);
-  for (uint16_t StreamIdx = 0; StreamIdx < StreamCount; ++StreamIdx) {
+  for (uint32_t StreamIdx = 0; StreamIdx < StreamCount; ++StreamIdx) {
     std::string Value;
     if (StreamIdx == OldMSFDirectory)
       Value = "Old MSF Directory";
@@ -294,7 +294,7 @@ Error LLVMOutputStyle::dumpStreamSummary() {
   uint32_t StreamCount = File.getNumStreams();
 
   ListScope L(P, "Streams");
-  for (uint16_t StreamIdx = 0; StreamIdx < StreamCount; ++StreamIdx) {
+  for (uint32_t StreamIdx = 0; StreamIdx < StreamCount; ++StreamIdx) {
     std::string Label("Stream ");
     Label += to_string(StreamIdx);
 

--- a/utils/TableGen/X86RecognizableInstr.cpp
+++ b/utils/TableGen/X86RecognizableInstr.cpp
@@ -917,7 +917,7 @@ void RecognizableInstr::emitDecodePath(DisassemblerTables &tables) const {
     uint8_t currentOpcode;
 
     for (currentOpcode = opcodeToSet;
-         currentOpcode < opcodeToSet + 8;
+         (unsigned)currentOpcode < (unsigned)opcodeToSet + 8;
          ++currentOpcode)
       tables.setTableFields(opcodeType,
                             insnContext(),


### PR DESCRIPTION
## PIPE-10306 , PIPE-10442, PIPE-10439 , PIPE-10422 , PIPE-10430 , PIPE-10444 , PIPE-10449 , PIPE-10445 , PIPE-10448 , PIPE-10418 , PIPE-10429 , PIPE-10432 , PIPE-10438 , PIPE-10434 , IPE-10436 , PIPE-10420 , PIPE-10431  , PIPE-10433 , PIPE-10441 , PIPE-10440 ,PIPE-10438 , PIPE-10422 , PIPE-10440 ,PIPE- 10437 ,PIPE- 10446 , PIPE-10451 ,PIPE- 10450 , PIPE-10457 ,PIPE- 10453, PIPE-10454 , PIPE-10455

This allows intermediate overflow, potentially causing incorrect calculations or security issues.

Solution
Cast at least one operand to the target type before performing the multiplication:
// SAFE - cast happens BEFORE multiplication
(int64_t)a * b
