### PR TITLE
PIPE-10437 LegalizeIntegerTypes

### DIFF
--- a/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -827,7 +827,9 @@ SDValue DAGTypeLegalizer::PromoteIntRes_VAARG(SDNode *N) {
     SDValue Part = DAG.getNode(ISD::ZERO_EXTEND, dl, NVT, Parts[i]);
     // Shift it to the right position and "or" it in.
     Part = DAG.getNode(ISD::SHL, dl, NVT, Part,
-                       DAG.getConstant(i * RegVT.getSizeInBits(), dl,
+                       DAG.getConstant(static_cast<uint64_t>(i) *
+                                           RegVT.getSizeInBits(),
+                                       dl,
                                        TLI.getPointerTy(DAG.getDataLayout())));
     Res = DAG.getNode(ISD::OR, dl, NVT, Res, Part);
   }


### PR DESCRIPTION
What
Fixes a HIGH severity SAST finding (PIPE-10437) in lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp at line 830, reported by Wiz.

Problem
In the PromoteIntRes_VAARG function, the expression i * RegVT.getSizeInBits() performs a unsigned × unsigned multiplication in 32-bit space. The result is then implicitly widened to int64_t when passed to DAG.getConstant(). Since the widening happens after the multiplication, the multiply can theoretically overflow before the conversion takes place.

This is flagged as CWE-190: Integer Overflow or Wraparound.

Fix
Cast i to uint64_t before the multiplication so the entire operation is performed in 64-bit space, eliminating any overflow window.


Why this is safe
getConstant() already accepts int64_t — no signature change needed

The cast is a widening conversion (uint32_t → uint64_t) — zero data loss risk

Produces identical machine code for all realistic input values

No functional behavior change — only eliminates the theoretical overflow path

No other files, headers, or dependencies are affected

Risk assessment
Functional behavior - None
Other files / dependencies - None
Build / compilation - None
Existing tests - All pass — no behavioral change