### PR TITLE
PIPE-10443 vulnerable fix coverage-report-server

### DIFF
--- a/tools/sancov/coverage-report-server.py
+++ b/tools/sancov/coverage-report-server.py
@@ -126,12 +126,6 @@ class ServerHandler(http.server.BaseHTTPRequestHandler):
     symcov_data = None
     src_path = None
 
-    def resolve_source_path(self, filename):
-        filepath = os.path.realpath(os.path.join(self.src_path, filename))
-        if os.path.commonpath([self.src_path, filepath]) != self.src_path:
-            return None
-        return filepath
-
     def do_GET(self):
         if self.path == '/':
             self.send_response(200)
@@ -154,8 +148,14 @@ class ServerHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(response.encode('UTF-8', 'replace'))
         elif self.symcov_data.has_file(self.path[1:]):
             filename = self.path[1:]
-            filepath = self.resolve_source_path(filename)
-            if filepath is None or not os.path.exists(filepath):
+            filepath = os.path.realpath(os.path.join(self.src_path, filename))
+
+            if not filepath.startswith(os.path.realpath(self.src_path) + os.sep):
+                self.send_response(403)
+                self.end_headers()
+                return
+
+            if not os.path.exists(filepath):
                 self.send_response(404)
                 self.end_headers()
                 return

--- a/tools/sancov/coverage-report-server.py
+++ b/tools/sancov/coverage-report-server.py
@@ -126,6 +126,12 @@ class ServerHandler(http.server.BaseHTTPRequestHandler):
     symcov_data = None
     src_path = None
 
+    def resolve_source_path(self, filename):
+        filepath = os.path.realpath(os.path.join(self.src_path, filename))
+        if os.path.commonpath([self.src_path, filepath]) != self.src_path:
+            return None
+        return filepath
+
     def do_GET(self):
         if self.path == '/':
             self.send_response(200)
@@ -148,8 +154,8 @@ class ServerHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(response.encode('UTF-8', 'replace'))
         elif self.symcov_data.has_file(self.path[1:]):
             filename = self.path[1:]
-            filepath = os.path.join(self.src_path, filename) 
-            if not os.path.exists(filepath):
+            filepath = self.resolve_source_path(filename)
+            if filepath is None or not os.path.exists(filepath):
                 self.send_response(404)
                 self.end_headers()
                 return
@@ -188,7 +194,7 @@ def main():
     print("Loading coverage...")
     symcov_json = json.load(args.symcov)
     ServerHandler.symcov_data = SymcovData(symcov_json)
-    ServerHandler.src_path = args.srcpath
+    ServerHandler.src_path = os.path.realpath(args.srcpath)
 
     socketserver.TCPServer.allow_reuse_address = True
     httpd = socketserver.TCPServer((args.host, args.port), ServerHandler)


### PR DESCRIPTION
Summary
Remediate CWE-22 path traversal findings on lines 152 and 163 of tools/sancov/coverage-report-server.py.

Problem
ServerHandler.do_GET built a file path directly from the request URL with os.path.join() and passed it to os.path.exists() and open() without validating that it stayed under the intended source directory. An attacker could request a path like GET /../../../etc/passwd to read files outside the source root.

Fix
The constructed filepath is now resolved to its canonical absolute form using os.path.realpath() before any file-system operation.
A startswith() check validates the resolved path against the canonical src_path root (plus os.sep). If the resolved path escapes the source root, the request is rejected with 403 Forbidden.
args.srcpath is normalized once at startup with os.path.realpath() so both sides of the comparison are canonical absolute paths.

Changes
do_GET: filepath is now built with os.path.realpath(os.path.join(...)) and validated inline with a startswith guard that returns 403 on traversal attempts, before the existing 404 existence check.
main: ServerHandler.src_path is set to os.path.realpath(args.srcpath) instead of the raw args.srcpath.

Testing
python3 -m py_compile coverage-report-server.py passes.
Valid source-file requests resolve correctly.
Traversal attempts (e.g., /../../../etc/passwd) are rejected with 403